### PR TITLE
[YONK-1306] Switch to ugettext_lazy to avoid issues on module load time

### DIFF
--- a/upload_validator/__init__.py
+++ b/upload_validator/__init__.py
@@ -5,7 +5,7 @@ import os
 
 import magic
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 from django.utils.deconstruct import deconstructible
 from django.core.exceptions import ValidationError
 


### PR DESCRIPTION
This PR fixes a small issue that happens when this module is imported at module load time.
The solution was to replace `ugettext` with `ugettext_lazy`.

**Testing instructions:**
1. On your solutions devstack, install group work xblocks and add it to some course
2. Run `paver devstack lms --fast` and check for `AppRegistryNotReady` errors that might pop up while the app boots.
 3. Clone this branch somewhere accessible by you devstack and install it on the `edxapp` venv with `pip install -e .`
4. Run `paver devstack lms --fast` and check that the `AppRegistryNotReady` errors that were caused by  group work xblocks vanished.

**Reviewers:**
- [ ] @Agrendalath