### PR TITLE
`ugettext_lazy` -> `gettext_lazy`

### DIFF
--- a/upload_validator/__init__.py
+++ b/upload_validator/__init__.py
@@ -5,7 +5,7 @@ import os
 
 import magic
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.utils.deconstruct import deconstructible
 from django.core.exceptions import ValidationError
 


### PR DESCRIPTION
`ugettext_lazy` was removed in Django 4 in favor of `gettext_lazy`.

Closes #17.